### PR TITLE
Feature/api update student list

### DIFF
--- a/backend/api/router/groups_routes.py
+++ b/backend/api/router/groups_routes.py
@@ -136,38 +136,6 @@ def upload_group(group_name):
 
         return Response(mimetype='application/json', status=201)
 
-    # @groups_routes.route('/api/v1/groups/<string:group_name>/update', methods=['POST'])
-    # def update_group(group_name):
-    #     f = request.files['file']
-    #     f.save('/tmp/' + f.filename)
-    #     student_list = gestprojlib.init_liste('/tmp/' + f.filename)
-    #
-    #     stored_users = gestprojlib.liste_etudiant_group(group_name)
-    #
-    #     users_list = []
-    #     new_students = []
-    #
-    #     for users in stored_users:
-    #         users_list.append(users.get('user')[0])
-    #
-    #     for s in student_list:
-    #         if s.get('login') not in users_list:
-    #             new_students.append(s.get('login'))
-    #
-    #     gestprojlib.create_users(new_students, group_name)
-    #
-    #     gestprojlib.create_sftp_users(new_students)
-    #
-    #     for u in users_list:
-    #         if u not in student_list:
-    #             os.system('userdel -r ' + u)
-    #             os.system('userdel -r ' + 'sftp.' + u)
-    #
-    #     f.close()
-    #     os.remove('/tmp/' + f.filename)
-
-    return Response(mimetype='application/json', status=201)
-
 
 @groups_routes.route('/api/v1/groups/<int:group_id>', methods=['DELETE'])
 def delete_group(group_id):

--- a/backend/api/router/users_routes.py
+++ b/backend/api/router/users_routes.py
@@ -1,21 +1,20 @@
 import json
 import os
-import pathlib
 import pwd
-
-from flask import Blueprint, Response, abort, request
 import sys
 
+from flask import Blueprint, Response, abort, request
+
+import gestprojlib as GP
 from api.model.user import User
 from api.utils.json_encoder import Encoder
-import gestprojlib as GP
 
 sys.path.append("/usr/src/app/gplib")
 
 users_routes = Blueprint("users_routes", __name__)
 
 
-@users_routes.route("/api/users", methods=["OPTIONS"])
+@users_routes.route("/api/v1/students", methods=["OPTIONS"])
 def preflight_get_users():
     """ Le front en VueJS execute une requête préliminaire pour vérifier la possibilité de faire un GET
     par défaut flask renvoie une redirection 302 qui n'est pas pris en charge par les navigateurs
@@ -23,7 +22,7 @@ def preflight_get_users():
     return Response(response=None, status=204)
 
 
-@users_routes.route("/api/users/", methods=["GET"])
+@users_routes.route("/api/v1/students/", methods=["GET"])
 def get_users():
     """ Retourne l'id, le nom et l'id du group des users dont l'id est supérieur à 10000 """
     users = []
@@ -40,7 +39,7 @@ def get_users():
     return Response(encoded_users, mimetype="application/json", status=200)
 
 
-@users_routes.route("/api/users/<int:user_id>/", methods=["GET"])
+@users_routes.route("/api/v1/students/<int:user_id>/", methods=["GET"])
 def get_user_by_id(user_id):
     try:
         user_trouve = pwd.getpwuid(user_id)
@@ -60,7 +59,7 @@ def get_user_by_id(user_id):
         abort(404, description="Resources not found")
 
 
-@users_routes.route("/api/create-users/", methods=["POST"])
+@users_routes.route("/api/v1/students/", methods=["POST"])
 def create_user():
     try:
         request_data = request.get_json()
@@ -69,40 +68,57 @@ def create_user():
         user_name = user_firstname + "." + user_lastname
         if pwd.getpwnam(user_name):
             response = {
-                "message": "L\'étudiant·e existe déjà !",
-                "icon": "mdi-alert-decagram",
-                "color": "error"
+                "message": "L\'étudiant·e existe déjà !"
             }
             return Response(json.dumps(response), mimetype="application/json", status=409)
     except KeyError:
         request_data = request.get_json()
         user_firstname = request_data["firstname"]
         user_lastname = request_data["lastname"]
-        user_group_id = int(request_data["groupId"])
+        user_group_name = request_data["groupName"]
         shell = "/bin/bash"
         skelpath = "../conf/skel"
         user_name = user_firstname + "." + user_lastname
-        path = pathlib.Path().absolute()
-        student_dir_path = str(path) + "/../home/etudiants/" + user_name
+        student_dir_path = "/home/etudiants/" + user_name
         os.makedirs(student_dir_path)
 
         os.system("useradd -d /home/etudiants/%s -K UID_MIN=10002 -m --skel %s -g %s -N --shell %s %s" % (
-            user_name, skelpath, user_group_id, shell, user_name))
+            user_name, skelpath, user_group_name, shell, user_name))
         os.system("usermod -p '*' %s" % user_name)
-        os.system("usermod -a -G %s %s" % (user_group_id, user_name))
+        os.system("usermod -a -G %s %s" % (user_group_name, user_name))
         os.system("chown root:root /home/etudiants/%s" % user_name)
 
-        user = pwd.getpwnam(user_name)
-        new_user = User(user.pw_uid, user.pw_name, user.pw_gid)
-        encoded_user = json.dumps(new_user, cls=Encoder)
+        os.system("useradd -d /home/etudiants/%s/sftp -K UID_MIN=10002 --shell %s -N -g %s sftp.%s" % (
+            user_name, shell, 'sftp', user_name))
+        os.system("usermod -p '*' sftp.%s" % user_name)
+        os.system("mkdir -p /home/etudiants/%s/sftp/Projets" % user_name)
+        os.system("mkdir -p /home/etudiants/%s/sftp/.ssh" % user_name)
+        os.system("chown root:root /home/etudiants/%s/sftp" % user_name)
+        os.system("chown sftp.%s:sftp /home/etudiants/%s/sftp/Projets" % (user_name, user_name))
+        os.system("chown sftp.%s:sftp /home/etudiants/%s/sftp/.ssh" % (user_name, user_name))
+        os.system("chmod 775 /home/etudiants/%s/sftp/Projets" % user_name)
 
-        return Response(encoded_user, mimetype="application/json", status=201)
+        return Response(mimetype="application/json", status=201)
 
 
-@users_routes.route("/api/users/group/<string:group_name>/", methods=["GET"])
+@users_routes.route("/api/v1/students/group/<string:group_name>/", methods=["GET"])
 def get_users_by_group(group_name):
     """
     Renvoie la liste de tous les utilisateurs appartenant au group "group_name"
     """
     liste = GP.liste_etudiant_group(group_name)
     return Response(json.dumps(liste, cls=Encoder), mimetype="application/json", status=200)
+
+
+@users_routes.route('/api/v1/students/<int:user_id>', methods=['DELETE'])
+def delete_user(user_id):
+    try:
+        user = pwd.getpwuid(user_id)
+
+        os.system('userdel -f --remove %s' % user.pw_name)
+        os.system("userdel -f --remove sftp.%s" % user.pw_name)
+
+        return Response('User ' + user.pw_name + ' has been deleted', mimetype='application/json', status=200)
+    except KeyError:
+        abort(404, description='Not found - Could not find user with ID ' + user_id)
+

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -18,6 +18,15 @@ components:
           type: array
           items:
             type: string
+    PostUserRequestDto:
+      type: object
+      properties:
+        firstname:
+          type: string
+        lastname:
+          type: string
+        groupName:
+          type: string
   parameters:
     group_id:
       in: path
@@ -33,6 +42,13 @@ components:
       required: true
       schema:
         type: string
+    user_id:
+      in: path
+      name: user_id
+      description: UIDs
+      required: true
+      schema:
+        type: integer
   responses:
     get-groups-200:
       description: GET groups list OK
@@ -149,7 +165,7 @@ paths:
       tags:
         - "groups"
       summary: "Upload CSV files to create Users with given group name, also use to update a group with a new CSV"
-      operationId: "postUsers"
+      operationId: "postUsersFromCSV"
       parameters:
         - $ref: "#/components/parameters/group_name"
       requestBody:
@@ -165,3 +181,41 @@ paths:
       responses:
         201:
           description: CREATED
+  /api/v1/students/:
+    post:
+      tags:
+        - "users"
+      summary: "Create new single user"
+      operationId: "postNewUser"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostUserRequestDto"
+      responses:
+        201:
+          description: CREATED
+        409:
+          description: CONFLICT
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                example:
+                  message: "L'étudiant·e existe déjà !"
+    delete:
+      tags:
+        - "users"
+      summary: "Delete user by UID"
+      operationId: "deleteUserById"
+      parameters:
+        - $ref: "#/components/parameters/user_id"
+      responses:
+        200:
+          description: OK
+        404:
+          description: "Not found - Could not find user with ID {userId}"

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -17,9 +17,7 @@ components:
         users_names:
           type: array
           items:
-            properties:
-              users_names:
-                type: string
+            type: string
   parameters:
     group_id:
       in: path
@@ -28,6 +26,13 @@ components:
       required: true
       schema:
         type: integer
+    group_name:
+      in: path
+      name: group_name
+      description: Group name
+      required: true
+      schema:
+        type: string
   responses:
     get-groups-200:
       description: GET groups list OK
@@ -44,13 +49,11 @@ components:
         - group_id: 10001
           group_name: ccm1
           users_names:
-            - users_names: "toto@toto.com"
-            - users_names: "tata@tata.com"
+            - "toto@toto.com, tata@tata.com"
         - group_id: 10002
           group_name: ccm2
           users_names:
-            - users_names: "toto@toto.com"
-            - users_names: "tata@tata.com"
+            - "toto.toto, tata.tata"
 paths:
   /api/v1/groups:
     get:
@@ -103,8 +106,7 @@ paths:
                     group_id: 10001
                     group_name: ccm1
                     users_names:
-                      - users_names: "toto@toto.com"
-                      - users_names: "tata@tata.com"
+                      - "toto.toto, tata.tata"
         404:
           description: "Not found - Could not find group with ID {groupId}"
     patch:
@@ -142,3 +144,24 @@ paths:
           description: OK
         404:
           description: "Not found - Could not find group with ID {groupId}"
+  /api/v1/groups/{group_name}/upload:
+    post:
+      tags:
+        - "groups"
+      summary: "Upload CSV files to create Users with given group name, also use to update a group with a new CSV"
+      operationId: "postUsers"
+      parameters:
+        - $ref: "#/components/parameters/group_name"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        201:
+          description: CREATED


### PR DESCRIPTION
Added: 
- POST /api/v1/groups/{group_name}/upload -> group can be created directly with a given csv file. This endpoint is all used to update an existing group with an updated CSV file.
- POST /api/v1/students -> create new user and sftp user
- DELETE /api/v1/students -> delete user and sftp user
- Improvements have been made on existing endpoint
- Update openapi documentation